### PR TITLE
Use a bigger keyspace for the primary key in mysql/mssql

### DIFF
--- a/sql/mssql.sql
+++ b/sql/mssql.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [locks] (
-  [id] int NOT NULL IDENTITY (1, 1),
+  [id] bigint NOT NULL IDENTITY (1, 1),
   [lockstring] varchar(128) NOT NULL,
   [created] datetime NOT NULL,
   [expires] datetime NOT NULL,

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -1,5 +1,5 @@
 CREATE TABLE semaphores (
-  id int PRIMARY KEY AUTO_INCREMENT,
+  id bigint unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT,
   lockstring varchar(128) UNIQUE,
   created datetime NOT NULL,
   expires datetime NOT NULL,


### PR DESCRIPTION
Also NOT NULL the mysql primary key (why was it nullable?)

The default signed integer primary key is pretty easy to max
out if you do a lot of locking over a long period of time.

Use a bigger keyspace and we get more time!

This doesn't solve the underlying issue which is that the primary
key should be reset every once in awhile probably.